### PR TITLE
Fixed PHPDocumentation

### DIFF
--- a/CloudControl/API.php
+++ b/CloudControl/API.php
@@ -120,7 +120,7 @@ class API {
      * @throws ThrottledError
      * @throws CCException
      *
-     * @return boolean
+     * @return $this
      */
     public function auth($email, $password) {
         $request = new Request($this->_url);
@@ -150,7 +150,7 @@ class API {
      *
      * @param string $token token to set
      *
-     * @return void
+     * @return $this
      */
     public function setToken($token) {
         if ($this->checkToken($token)) {


### PR DESCRIPTION
Our application was expecting a boolean to be returned by the auth() function. However, this seems to have been changed overtime. How is determined whether an authentication is successful? It seems the only way is to use 'checkToken()' after authentication. 

It would be better to have 'setToken()' return a boolean, however this might break other stuff that depends on the $this being returned now...
